### PR TITLE
WEB-10712: Add optional Docker GHA layer caching to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,10 @@ on:
         type: boolean
         required: false
         default: false
+      docker-cache:
+        type: boolean
+        required: false
+        default: false
       kms-image-name:
         type: string
         required: false
@@ -79,16 +83,37 @@ jobs:
             --key ${{ inputs.kms-key-name }} \
             --input-dir /tmp/encrypted \
             --output-dir /tmp/decrypted
+      - name: Set up Docker Buildx
+        if: inputs.docker-cache == true
+        uses: docker/setup-buildx-action@v3
       - name: Build
-        if: inputs.docker-profile == ''
+        if: inputs.docker-profile == '' && inputs.docker-cache == false
         env:
           DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
         run: docker compose -f ${{ inputs.docker-compose-file }} build
       - name: Build (with profile)
-        if: inputs.docker-profile != ''
+        if: inputs.docker-profile != '' && inputs.docker-cache == false
         env:
           DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
         run: docker compose --profile ${{ inputs.docker-profile }} -f ${{ inputs.docker-compose-file }} build
+      - name: Build (with GHA cache)
+        if: inputs.docker-profile == '' && inputs.docker-cache == true
+        env:
+          DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
+        run: |
+          docker buildx bake \
+            -f ${{ inputs.docker-compose-file }} \
+            --set "*.cache-from=type=gha" \
+            --set "*.cache-to=type=gha,mode=max"
+      - name: Build (with profile, with GHA cache)
+        if: inputs.docker-profile != '' && inputs.docker-cache == true
+        env:
+          DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
+        run: |
+          docker buildx bake \
+            -f ${{ inputs.docker-compose-file }} \
+            --set "*.cache-from=type=gha" \
+            --set "*.cache-to=type=gha,mode=max"
       - name: Tests (unit)
         if: inputs.unit-test-cmd != ''
         env:


### PR DESCRIPTION
## Summary

- Adds optional `docker-cache` boolean input (default: `false`) to `build.yaml` for backwards compatibility with all existing callers
- When `docker-cache: true`, sets up Docker Buildx and uses `docker buildx bake` with `type=gha,mode=max` as both cache source and destination
- Existing `docker compose build` steps are unchanged for callers not opting in

## Test plan

- [ ] Verify existing callers (vouch, audio-backend, reporting-service, api-ingestion) are unaffected — they pass no `docker-cache` input so hit the unchanged path
- [ ] Verify api-backend CI shows reduced Docker build time on repeat PR runs after opting in via [api-backend#WEB-10712](https://github.com/lickdltd/api-backend/pull/new/WEB-10712)

Closes WEB-10712

🤖 Generated with [Claude Code](https://claude.com/claude-code)