### PR TITLE
Add COMPOSER_AUTH to all build steps for private GitHub packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,11 +90,13 @@ jobs:
         if: inputs.docker-profile == '' && inputs.docker-cache == false
         env:
           DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
+          COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.ghcr-pat }}"}}'
         run: docker compose -f ${{ inputs.docker-compose-file }} build
       - name: Build (with profile)
         if: inputs.docker-profile != '' && inputs.docker-cache == false
         env:
           DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
+          COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.ghcr-pat }}"}}'
         run: docker compose --profile ${{ inputs.docker-profile }} -f ${{ inputs.docker-compose-file }} build
       - name: Build (with GHA cache)
         if: inputs.docker-profile == '' && inputs.docker-cache == true
@@ -108,6 +110,7 @@ jobs:
         env:
           DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
           DOCKER_IMAGE_URL: ${{ inputs.docker-image-url }}
+          COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.ghcr-pat }}"}}'
       - name: Build (with profile, with GHA cache)
         if: inputs.docker-profile != '' && inputs.docker-cache == true
         uses: docker/bake-action@v5
@@ -120,6 +123,7 @@ jobs:
         env:
           DOCKER_TAG: ${{ steps.setup.outputs.git-hash-short }}
           DOCKER_IMAGE_URL: ${{ inputs.docker-image-url }}
+          COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.ghcr-pat }}"}}'
       - name: Tests (unit)
         if: inputs.unit-test-cmd != ''
         env:


### PR DESCRIPTION
## Summary

- Adds `COMPOSER_AUTH` env var to all four build steps (`Build`, `Build (with profile)`, `Build (with GHA cache)`, `Build (with profile, with GHA cache)`)
- Uses the already-declared `ghcr-pat` secret — no new secrets needed
- Purely additive: repos without a `COMPOSER_AUTH` build arg in their Dockerfile silently ignore it; only repos that explicitly wire it up (e.g. `lickdltd/slack-gateway`) benefit

## Test plan

- [ ] Verify a repo that does **not** use `COMPOSER_AUTH` builds without issue
- [ ] Verify `slack-gateway` (or equivalent) can pull private GitHub packages during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)